### PR TITLE
Update brownie-config.yaml

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -9,6 +9,9 @@ autofetch_sources: True
 dependencies:
   - OpenZeppelin/openzeppelin-contracts@3.0.0
 
+# Automatically exports the environment variables from .env
+dotenv: .env
+
 # path remapping to support OpenZepplin imports with NPM-style path
 compiler:
   solc:


### PR DESCRIPTION
Added dotenv parameter. Otherwise brownie fails to spin up a local ganache chain or to connect to Infura due to missing environment variables, unless they are manually exported. This might seem like something small but its not very obvious for newbies.